### PR TITLE
Added garlic patern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/multiformats/go-multiaddr-fmt
 
 require (
-	github.com/multiformats/go-multiaddr v0.0.1
+	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-dns v0.0.2
 )

--- a/patterns.go
+++ b/patterns.go
@@ -41,11 +41,25 @@ var UTP = And(UDP, Base(ma.P_UTP))
 // Define QUIC as 'quic' on top of udp (on top of ipv4 or ipv6)
 var QUIC = And(UDP, Base(ma.P_QUIC))
 
-// Define unreliable transport as udp
+// Define garlic32 (i2p hashed) as it self
+var GARLIC32 = Base(ma.P_GARLIC32)
+
+// Define garlic64 (i2p destination) as it self
+var GARLIC64 = Base(ma.P_GARLIC64)
+
+// Define garlic (i2p destination or hashed) as any of garlic32 or garlic64
+var GARLIC = Or(GARLIC64, GARLIC32)
+
+// Define sam3 as tcp or udp and sam3
+// Sam3 have a special case, he can't be used to connect to other peers but his
+// instance allow to listen and connect garlic
+var SAM3 = And(Or(TCP, UDP), Base(ma.P_SAM3))
+
+// Define unreliable transport as udp or sam3
 var Unreliable = Or(UDP)
 
-// Now define a Reliable transport as either tcp or utp or quic
-var Reliable = Or(TCP, UTP, QUIC)
+// Now define a Reliable transport as either tcp or utp or quic or garlic
+var Reliable = Or(TCP, UTP, QUIC, GARLIC)
 
 // IPFS can run over any reliable underlying transport protocol
 var IPFS = And(Reliable, Base(ma.P_IPFS))

--- a/patterns_test.go
+++ b/patterns_test.go
@@ -38,6 +38,26 @@ var TestVectors = map[string]*testVector{
 		Good:    []string{"/ip4/1.2.3.4/udp/1234/quic", "/ip6/::/udp/1234/quic"},
 		Bad:     []string{"/ip4/0.0.0.0/tcp/12345/quic", "/ip6/1.2.3.4/ip4/0.0.0.0/udp/1234/quic", "/quic"},
 	},
+	"SAM3": {
+		Pattern: SAM3,
+		Good:    []string{"/ip4/1.2.3.4/udp/1234/sam3/3|3|6|6|2|2", "/ip6/::1/tcp/1234/sam3/3|3|6|6|2|2"},
+		Bad:     []string{"/ip4/0.0.0.0/sam3/3|3|6|6|2|2", "/sam3/3|3|6|6|2|2", "/sam3"},
+	},
+	"GARLIC": {
+		Pattern: GARLIC,
+		Good: []string{
+			"/garlic32/6zlio2ipbnmir26nrspdbt4cqnhu52ekw2gw6kfca4p77tdtsmja",
+			"/garlic64/Z1XdSy9zNg1IaFfDqWhpzoSjlf-lAWT4YkrRkq3rsnQyY69QXc~-2Xeyoj7~36swjrHjlH-OqvTbM0jFAc2RzIQ1VEf9uDUAz1sso9~or1xIDxsEUmgK~TQvHMPNFwVGhMxZ7K4LkLbi~sN2WlZB49FhhWVgD-nV-WfuRi~aByMUGtM1SqBML-Ok1bI6Pw9o6VIM-aFG7RLj1s8RsJOCzkugKLMsW-k5gXze6QJlRJKlcHI23bf-LPqhTfVe2HpEjS5DAj1fohtY63V3Kksd34Ejh86I-njBYGG66enBHvM-sRKAUQIKAt7eJEuk7l5BcidGD4HqodRl1nYBrHoP0MFDtw4ZTLcefVCwZ~OttpnUdH~9RBPBxc9Da-mVOe9dh608anxuXTBaKzdN6FQjxnMPEMQe5pBPzjGrkUpgCJLduybMltVymlYIMR98dPpBskqJQjuEm5tHBSWJfiKD9POVKIV0yyjlakoHm4Y~Zrl14GdFTIf2BGHMjf9GP0Q5BQAEAAcAAA==",
+		},
+		Bad: []string{
+			"/ip4/0.0.0.0/tcp/12345/garlic32/6zlio2ipbnmir26nrspdbt4cqnhu52ekw2gw6kfca4p77tdtsmja",
+			"/ip4/0.0.0.0/tcp/12345/garlic64/Z1XdSy9zNg1IaFfDqWhpzoSjlf-lAWT4YkrRkq3rsnQyY69QXc~-2Xeyoj7~36swjrHjlH-OqvTbM0jFAc2RzIQ1VEf9uDUAz1sso9~or1xIDxsEUmgK~TQvHMPNFwVGhMxZ7K4LkLbi~sN2WlZB49FhhWVgD-nV-WfuRi~aByMUGtM1SqBML-Ok1bI6Pw9o6VIM-aFG7RLj1s8RsJOCzkugKLMsW-k5gXze6QJlRJKlcHI23bf-LPqhTfVe2HpEjS5DAj1fohtY63V3Kksd34Ejh86I-njBYGG66enBHvM-sRKAUQIKAt7eJEuk7l5BcidGD4HqodRl1nYBrHoP0MFDtw4ZTLcefVCwZ~OttpnUdH~9RBPBxc9Da-mVOe9dh608anxuXTBaKzdN6FQjxnMPEMQe5pBPzjGrkUpgCJLduybMltVymlYIMR98dPpBskqJQjuEm5tHBSWJfiKD9POVKIV0yyjlakoHm4Y~Zrl14GdFTIf2BGHMjf9GP0Q5BQAEAAcAAA==",
+			"/garlic32",
+			"/garlic64",
+			"/garlic32/Z1XdSy9zNg1IaFfDqWhpzoSjlf-lAWT4YkrRkq3rsnQyY69QXc~-2Xeyoj7~36swjrHjlH-OqvTbM0jFAc2RzIQ1VEf9uDUAz1sso9~or1xIDxsEUmgK~TQvHMPNFwVGhMxZ7K4LkLbi~sN2WlZB49FhhWVgD-nV-WfuRi~aByMUGtM1SqBML-Ok1bI6Pw9o6VIM-aFG7RLj1s8RsJOCzkugKLMsW-k5gXze6QJlRJKlcHI23bf-LPqhTfVe2HpEjS5DAj1fohtY63V3Kksd34Ejh86I-njBYGG66enBHvM-sRKAUQIKAt7eJEuk7l5BcidGD4HqodRl1nYBrHoP0MFDtw4ZTLcefVCwZ~OttpnUdH~9RBPBxc9Da-mVOe9dh608anxuXTBaKzdN6FQjxnMPEMQe5pBPzjGrkUpgCJLduybMltVymlYIMR98dPpBskqJQjuEm5tHBSWJfiKD9POVKIV0yyjlakoHm4Y~Zrl14GdFTIf2BGHMjf9GP0Q5BQAEAAcAAA==",
+			"/garlic64/6zlio2ipbnmir26nrspdbt4cqnhu52ekw2gw6kfca4p77tdtsmja",
+		},
+	},
 	"IPFS": {
 		Pattern: IPFS,
 		Good: []string{
@@ -45,6 +65,8 @@ var TestVectors = map[string]*testVector{
 			"/ip6/::/tcp/1234/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 			"/ip6/::/udp/1234/utp/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 			"/ip4/0.0.0.0/udp/1234/utp/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+			"/garlic32/6zlio2ipbnmir26nrspdbt4cqnhu52ekw2gw6kfca4p77tdtsmja/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+			"/garlic64/Z1XdSy9zNg1IaFfDqWhpzoSjlf-lAWT4YkrRkq3rsnQyY69QXc~-2Xeyoj7~36swjrHjlH-OqvTbM0jFAc2RzIQ1VEf9uDUAz1sso9~or1xIDxsEUmgK~TQvHMPNFwVGhMxZ7K4LkLbi~sN2WlZB49FhhWVgD-nV-WfuRi~aByMUGtM1SqBML-Ok1bI6Pw9o6VIM-aFG7RLj1s8RsJOCzkugKLMsW-k5gXze6QJlRJKlcHI23bf-LPqhTfVe2HpEjS5DAj1fohtY63V3Kksd34Ejh86I-njBYGG66enBHvM-sRKAUQIKAt7eJEuk7l5BcidGD4HqodRl1nYBrHoP0MFDtw4ZTLcefVCwZ~OttpnUdH~9RBPBxc9Da-mVOe9dh608anxuXTBaKzdN6FQjxnMPEMQe5pBPzjGrkUpgCJLduybMltVymlYIMR98dPpBskqJQjuEm5tHBSWJfiKD9POVKIV0yyjlakoHm4Y~Zrl14GdFTIf2BGHMjf9GP0Q5BQAEAAcAAA==/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 		},
 		Bad: []string{
 			"/ip4/1.2.3.4/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",


### PR DESCRIPTION
I need these for my `sam3` transport.
I chosed to put garlic as a reliable transport because doing udp or tcp over garlic will make the code of both transport way more complicated, tcp or udp in the application side isn't efficient and i2p reimplement his own tcp or udp. So I think doing `p2p` directly over `garlic64` is the best to go right now.
Also i2p's tcp or udp havn't any port.

# Need :
- [ ] multiformats/go-multiaddr#107