### PR TITLE
fix: remove dnsaddr from dns matcher

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -15,7 +15,6 @@ var DNS6 = Base(ma.P_DNS6)
 // Define a dnsaddr, dns, dns4 or dns6 format multiaddr
 var DNS = Or(
 	Base(ma.P_DNS),
-	Base(ma.P_DNSADDR),
 	DNS4,
 	DNS6,
 )


### PR DESCRIPTION
dnsaddr is a special beast. It's technically a DNS address, but it can resolve
to any multiaddr, not just an IP address.